### PR TITLE
license-maven-plugin updates:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ target/
 /bin/
 *~
 
+.vscode
+
 nb-configuration.xml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Easier upgrading of all plugins.
 
 ## Changelog
 
+### Latest (dev)
+* Upgrade license-maven-plugin to 4.2
+* license-maven-plugin is using the git plugin to correctly compute year ranges in license headers
+
 ### 5.20
 * Correcting repository URLs
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
             <plugin>
               <groupId>com.mycila</groupId>
               <artifactId>license-maven-plugin</artifactId>
-              <version>3.0</version>
+              <version>4.2</version>
               <configuration>
                 <keywords>
                   <keyword>License</keyword>
@@ -250,6 +250,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
                 ]]></inlineHeader>
               </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>com.mycila</groupId>
+                  <artifactId>license-maven-plugin-git</artifactId>
+                  <!-- make sure you use the same version as license-maven-plugin -->
+                  <version>4.2</version>
+                </dependency>
+              </dependencies>
               <executions>
                 <execution>
                   <id>license</id>


### PR DESCRIPTION
* Upgrade license-maven-plugin to 4.2
* license-maven-plugin is using the git plugin to correctly compute year ranges in license headers